### PR TITLE
Movie page - 

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: yarn && yarn build && yarn run export
         env:
-            MOVIEDB_API_KEY: ${{ secrets.MOVIEDB_API_KEY }}
+            NEXT_PUBLIC_MOVIEDB_API_KEY: ${{ secrets.MOVIEDB_API_KEY }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: yarn && yarn build && yarn run export
         env:
-            MOVIEDB_API_KEY: ${{ secrets.MOVIEDB_API_KEY }}
+            NEXT_PUBLIC_MOVIEDB_API_KEY: ${{ secrets.MOVIEDB_API_KEY }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "firebase": "^9.4.0",
     "next": "^11",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "swr": "^1.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -82,7 +82,7 @@ export default function Home({posts}) {
 }
 
 export async function getStaticProps({preview = null}) {
-  const res = await fetch('https://api.themoviedb.org/3/discover/movie?api_key=' + process.env.MOVIEDB_API_KEY);
+  const res = await fetch('https://api.themoviedb.org/3/discover/movie?api_key=' + process.env.NEXT_PUBLIC_MOVIEDB_API_KEY);
   const posts = await res.json();
   return {
     props: {posts, preview},

--- a/pages/movie/[id].tsx
+++ b/pages/movie/[id].tsx
@@ -1,14 +1,29 @@
 import Link from "next/link";
 import Image from 'next/image'
+import useSWR from "swr";
+import { useRouter } from "next/router";
 
-function MoviePage({movie}) {
+
+const fetcher = (url) => fetch(url).then(res => res.json());
+
+function MoviePage() {
+    const router = useRouter()
+    const { id } = router.query
+    const { data, error } = useSWR(`https://api.themoviedb.org/3/movie/${id}?api_key=` + process.env.NEXT_PUBLIC_MOVIEDB_API_KEY, fetcher);
+
+    if (!data) return <p>Loading...</p>;
+    if (error) return <p>Error :(</p>;
+
+    console.log(data);
+
+
     return <div>
-        <h1>{movie.title}</h1>
-        <Image loader={tmdbLoader} src={movie.poster_path} alt={movie.title} width={200} height={300}/>
+        <h1>{data.title}</h1>
+        <Image loader={tmdbLoader} src={data.poster_path} alt={data.title} width={200} height={300} />
         <section>Information about the film
-            <p>{movie.overview}</p>
-            <p>{movie.production_companies.map(e => e.name).join(', ')}</p>
-            <p>{movie.genres.map(e => e.name).join(', ')}</p>
+            <p>{data.overview}</p>
+            <p>{data.production_companies.map(e => e.name).join(', ')}</p>
+            <p>{data.genres.map(e => e.name).join(', ')}</p>
             <p>Stars</p>
             <span>Rating</span>
             <Link href={'/'}>
@@ -18,16 +33,7 @@ function MoviePage({movie}) {
     </div>
 }
 
-export async function getServerSideProps(context) {
-    const movieId = context.params.id;
-    const res = await fetch(`https://api.themoviedb.org/3/movie/${movieId}?api_key=` + process.env.MOVIEDB_API_KEY);
-    const movie = await res.json();
-    return {
-        props: {movie}
-    }
-}
-
-const tmdbLoader = ({src, width, quality}) => {
+const tmdbLoader = ({ src, width, quality }) => {
     return `https://image.tmdb.org/t/p/w500/${src}?w=${width}&q=${quality || 75}`
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3737,6 +3737,11 @@ supports-color@^8.0.0:
   dependencies:
     has-flag "^4.0.0"
 
+swr@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-1.1.2.tgz#9f3de2541931fccf03c48f322f1fc935a7551612"
+  integrity sha512-UsM0eo5T+kRPyWFZtWRx2XR5qzohs/LS4lDC0GCyLpCYFmsfTk28UCVDbOE9+KtoXY4FnwHYiF+ZYEU3hnJ1lQ==
+
 table@^6.0.9:
   version "6.7.3"
   resolved "https://registry.yarnpkg.com/table/-/table-6.7.3.tgz#255388439715a738391bd2ee4cbca89a4d05a9b7"


### PR DESCRIPTION
### Context
With the introduction of #11  the new movie page using server-side rendering, it is no longer possible to statically generate the app and deploy it to firebase. 

### Fix
The movie page should be Client-Side Rendered (CSR) meaning the API call to themoviedb should be performed from the browser. 

Implemented:
 * Add [SWR Library](https://swr.vercel.app/)
 * Call the API with SWR
 * Change environment variable from `MOVIEDB_API_KEY` to `NEXT_PUBLIC_MOVIEDB_API_KEY`

⚠️ After this PR, please update your local .env file to export `NEXT_PUBLIC_MOVIEDB_API_KEY`

closes #12 