### PR TITLE
Persist rating for authenticated user

### DIFF
--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -1,24 +1,23 @@
-import Image from 'next/image';
 import Link from 'next/link';
-
+import { useAuth } from "../../lib/firebase.auth";
 import styles from './Header.module.css';
-import { useAuth } from '../../lib/firebase';
+
 
 export default function Header() {
-    const { user, signOutUser } = useAuth();
+    const { user, signout } = useAuth();
 
     return <header className={styles.header}>Five Stars
         <nav className={styles.navitem}>
-           <Link href="/">Home</Link>
+            <Link href="/">Home</Link>
 
-           { user ? 
-            <div>
-                <div>{ user.email }</div>
-                <img src={user.photoURL} width={40} height={40}></img>
-                <button onClick={() => signOutUser()}>Log out</button>
-            </div>
-           : <div></div>
-           }
+            {user ?
+                <div>
+                    <div>{user.email}</div>
+                    <img src={user.photoUrl} width={40} height={40}></img>
+                    <button onClick={() => signout()}>Log out</button>
+                </div>
+                : <div></div>
+            }
         </nav>
     </header>
 }

--- a/components/ratings/Ratings.tsx
+++ b/components/ratings/Ratings.tsx
@@ -1,20 +1,28 @@
-import { doc, getFirestore, updateDoc } from 'firebase/firestore';
+import { doc, getDoc, getFirestore, setDoc } from 'firebase/firestore';
 import firebaseApp from '../../lib/firebase';
+import { useAuth } from '../../lib/firebase.auth';
+import { useDB } from '../../lib/firebase.db';
 import styles from './Ratings.module.css';
 
 const db = getFirestore(firebaseApp);
 
 
-export default function Ratings({movie}) {
-    
-    const rateMovie = async (id: string, rating: number) => {
-      await updateDoc(doc(db, 'users', 't6aEmLDMWEzR839g5XsP'), {
-        ['ratings.' + id]: rating
-      });
-    };
+export default function Ratings({ movie }) {
 
-    return <div className={styles.stars}>
-    <span onClick={() => rateMovie(movie.id, 1)}>☆</span>
+  const { user } = useAuth();
+  const { ratings } = useDB();
+
+  const rateMovie = async (id: string, rating: number) => {
+    await setDoc(doc(db, 'users', user.uid), {
+      ratings: {
+        [id]: rating
+      }
+    }, { merge: true });
+  };
+
+  return <div className={styles.stars}>
+    {ratings && ratings[movie.id] && <span>{ratings[movie.id]}</span>}
+    <span className='dd' onClick={() => rateMovie(movie.id, 1)}>☆</span>
     <span onClick={() => rateMovie(movie.id, 2)}>☆</span>
     <span onClick={() => rateMovie(movie.id, 3)}>☆</span>
     <span onClick={() => rateMovie(movie.id, 4)}>☆</span>

--- a/components/ratings/Ratings.tsx
+++ b/components/ratings/Ratings.tsx
@@ -1,7 +1,6 @@
-import { doc, getDoc, getFirestore, setDoc } from 'firebase/firestore';
+import { doc, getFirestore, setDoc } from 'firebase/firestore';
 import firebaseApp from '../../lib/firebase';
 import { useAuth } from '../../lib/firebase.auth';
-import { useDB } from '../../lib/firebase.db';
 import styles from './Ratings.module.css';
 
 const db = getFirestore(firebaseApp);
@@ -10,7 +9,6 @@ const db = getFirestore(firebaseApp);
 export default function Ratings({ movie }) {
 
   const { user } = useAuth();
-  const { ratings } = useDB();
 
   const rateMovie = async (id: string, rating: number) => {
     await setDoc(doc(db, 'users', user.uid), {
@@ -21,7 +19,7 @@ export default function Ratings({ movie }) {
   };
 
   return <div className={styles.stars}>
-    {ratings && ratings[movie.id] && <span>{ratings[movie.id]}</span>}
+    {user?.ratings && user.ratings[movie.id] && <span>{user.ratings[movie.id]}</span>}
     <span className='dd' onClick={() => rateMovie(movie.id, 1)}>☆</span>
     <span onClick={() => rateMovie(movie.id, 2)}>☆</span>
     <span onClick={() => rateMovie(movie.id, 3)}>☆</span>

--- a/components/ratings/Ratings.tsx
+++ b/components/ratings/Ratings.tsx
@@ -1,4 +1,4 @@
-import { doc, getFirestore, setDoc } from 'firebase/firestore';
+import { getFirestore } from 'firebase/firestore';
 import firebaseApp from '../../lib/firebase';
 import { useAuth } from '../../lib/firebase.auth';
 import styles from './Ratings.module.css';
@@ -8,22 +8,14 @@ const db = getFirestore(firebaseApp);
 
 export default function Ratings({ movie }) {
 
-  const { user } = useAuth();
-
-  const rateMovie = async (id: string, rating: number) => {
-    await setDoc(doc(db, 'users', user.uid), {
-      ratings: {
-        [id]: rating
-      }
-    }, { merge: true });
-  };
+  const { user, rateMovie } = useAuth();
 
   return <div className={styles.stars}>
     {user?.ratings && user.ratings[movie.id] && <span>{user.ratings[movie.id]}</span>}
-    <span className='dd' onClick={() => rateMovie(movie.id, 1)}>☆</span>
-    <span onClick={() => rateMovie(movie.id, 2)}>☆</span>
-    <span onClick={() => rateMovie(movie.id, 3)}>☆</span>
+    <span className='dd' onClick={() => rateMovie(movie.id, 5)}>☆</span>
     <span onClick={() => rateMovie(movie.id, 4)}>☆</span>
-    <span onClick={() => rateMovie(movie.id, 5)}>☆</span>
+    <span onClick={() => rateMovie(movie.id, 3)}>☆</span>
+    <span onClick={() => rateMovie(movie.id, 2)}>☆</span>
+    <span onClick={() => rateMovie(movie.id, 1)}>☆</span>
   </div>
 }

--- a/lib/firebase.auth.tsx
+++ b/lib/firebase.auth.tsx
@@ -2,14 +2,15 @@ import { getAuth, GoogleAuthProvider, onIdTokenChanged, signInWithEmailAndPasswo
 import { doc, getDoc, getFirestore } from 'firebase/firestore';
 import Router from 'next/router';
 import { createContext, useContext, useEffect, useState } from 'react';
-import { createUser } from './firebase.db';
+import { createUser, dbRateMovie } from './firebase.db';
 
 interface AuthContext {
-  user: any;
+  user: { uid: string, email: string, ratings: any };
   loading: boolean;
   signinWithEmail: (email: string, password: string) => Promise<any>;
   signinWithGoogle: (redirect?: string) => Promise<any>;
   signout: () => Promise<any>;
+  rateMovie: (id: string, ratings: number) => void;
 }
 
 const authContext = createContext<AuthContext>(undefined);
@@ -29,7 +30,6 @@ const db = getFirestore();
 function useProvideAuth() {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
-
 
   const handleUser = async (rawUser) => {
     if (rawUser) {
@@ -72,6 +72,12 @@ function useProvideAuth() {
     return signOut(auth).then(() => handleUser(false));
   };
 
+  const rateMovie = (id, rating) => {
+    setUser(user => ({ ...user, ratings: { ...user.ratings, [id]: rating } }));
+    dbRateMovie(user.uid, id, rating);
+  }
+
+
   useEffect(() => {
     const unsubscribe = onIdTokenChanged(auth, handleUser);
 
@@ -81,6 +87,7 @@ function useProvideAuth() {
   return {
     user,
     loading,
+    rateMovie,
     signinWithEmail,
     signinWithGoogle,
     signout

--- a/lib/firebase.auth.tsx
+++ b/lib/firebase.auth.tsx
@@ -5,7 +5,7 @@ import { createContext, useContext, useEffect, useState } from 'react';
 import { createUser, dbRateMovie } from './firebase.db';
 
 interface AuthContext {
-  user: { uid: string, email: string, ratings: any };
+  user: { uid: string, email: string, ratings: any, photoUrl: string };
   loading: boolean;
   signinWithEmail: (email: string, password: string) => Promise<any>;
   signinWithGoogle: (redirect?: string) => Promise<any>;

--- a/lib/firebase.auth.tsx
+++ b/lib/firebase.auth.tsx
@@ -1,4 +1,5 @@
 import { getAuth, GoogleAuthProvider, onIdTokenChanged, signInWithEmailAndPassword, signInWithPopup, signOut } from 'firebase/auth';
+import { doc, getDoc, getFirestore } from 'firebase/firestore';
 import Router from 'next/router';
 import { createContext, useContext, useEffect, useState } from 'react';
 import { createUser } from './firebase.db';
@@ -23,12 +24,11 @@ export const useAuth = () => {
 };
 
 const auth = getAuth();
+const db = getFirestore();
 
 function useProvideAuth() {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
-
-  console.log(user);
 
 
   const handleUser = async (rawUser) => {
@@ -89,12 +89,15 @@ function useProvideAuth() {
 
 const formatUser = async (user) => {
   const token = await user.getIdToken();
+  const userData = await getDoc(doc(db, 'users', user.uid));
+
   return {
     uid: user.uid,
     email: user.email,
     name: user.displayName,
     provider: user.providerData[0].providerId,
     photoUrl: user.photoURL,
+    ratings: userData.data().ratings,
     token
   };
 };

--- a/lib/firebase.auth.tsx
+++ b/lib/firebase.auth.tsx
@@ -1,0 +1,100 @@
+import { getAuth, GoogleAuthProvider, onIdTokenChanged, signInWithEmailAndPassword, signInWithPopup, signOut } from 'firebase/auth';
+import Router from 'next/router';
+import { createContext, useContext, useEffect, useState } from 'react';
+import { createUser } from './firebase.db';
+
+interface AuthContext {
+  user: any;
+  loading: boolean;
+  signinWithEmail: (email: string, password: string) => Promise<any>;
+  signinWithGoogle: (redirect?: string) => Promise<any>;
+  signout: () => Promise<any>;
+}
+
+const authContext = createContext<AuthContext>(undefined);
+
+export function AuthProvider({ children }) {
+  const auth = useProvideAuth();
+  return <authContext.Provider value={auth}>{children}</authContext.Provider>;
+}
+
+export const useAuth = () => {
+  return useContext(authContext);
+};
+
+const auth = getAuth();
+
+function useProvideAuth() {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  console.log(user);
+
+
+  const handleUser = async (rawUser) => {
+    if (rawUser) {
+      const user = await formatUser(rawUser);
+      const { token, ...userWithoutToken } = user;
+
+      createUser(user.uid, userWithoutToken);
+      setUser(user);
+      setLoading(false);
+      return user;
+    } else {
+      setUser(false);
+      setLoading(false);
+      return false;
+    }
+  };
+
+  const signinWithEmail = (email, password) => {
+    setLoading(true);
+    return signInWithEmailAndPassword(auth, email, password).then((response) => {
+      handleUser(response.user);
+      Router.push('/sites');
+    });
+  };
+
+  const signinWithGoogle = (redirect) => {
+    setLoading(true);
+    return signInWithPopup(auth, new GoogleAuthProvider()).then((response) => {
+      handleUser(response.user);
+
+      if (redirect) {
+        Router.push(redirect);
+      }
+    });
+  };
+
+  const signout = () => {
+    Router.push('/');
+
+    return signOut(auth).then(() => handleUser(false));
+  };
+
+  useEffect(() => {
+    const unsubscribe = onIdTokenChanged(auth, handleUser);
+
+    return () => unsubscribe();
+  }, []);
+
+  return {
+    user,
+    loading,
+    signinWithEmail,
+    signinWithGoogle,
+    signout
+  };
+}
+
+const formatUser = async (user) => {
+  const token = await user.getIdToken();
+  return {
+    uid: user.uid,
+    email: user.email,
+    name: user.displayName,
+    provider: user.providerData[0].providerId,
+    photoUrl: user.photoURL,
+    token
+  };
+};

--- a/lib/firebase.db.ts
+++ b/lib/firebase.db.ts
@@ -1,33 +1,16 @@
-import { doc, getDoc, getFirestore, setDoc } from "firebase/firestore";
-import { useEffect, useState } from "react";
+import { doc, getFirestore, setDoc } from "firebase/firestore";
 import firebaseApp from "./firebase";
-import { useAuth } from "./firebase.auth";
 
 const db = getFirestore(firebaseApp);
 
-export function createUser(uid, data) {
+export const createUser = (uid, data) => {
   return setDoc(doc(db, 'users', uid), { uid, ...data }, { merge: true });
-}
+};
 
-export const useDB = () => {
-  const { user } = useAuth();
-  const [ratings, setRatings] = useState({});
-  const [loading, setLoading] = useState(false);
-
-  const getRatings = async () => {
-    if (user) {
-      const userRatings = await getDoc(doc(db, 'users', user.uid));
-      return userRatings.data().ratings;
+export const dbRateMovie = async (userId: string, id: string, rating: number) => {
+  await setDoc(doc(db, 'users', userId), {
+    ratings: {
+      [id]: rating
     }
-  };
-
-  useEffect(() => {
-    setLoading(true);
-    getRatings().then(ratings => {
-      setRatings(ratings);
-      setLoading(false);
-    })
-  }, [user]);
-
-  return { ratings, loading, };
-}
+  }, { merge: true });
+};

--- a/lib/firebase.db.ts
+++ b/lib/firebase.db.ts
@@ -1,0 +1,33 @@
+import { doc, getDoc, getFirestore, setDoc } from "firebase/firestore";
+import { useEffect, useState } from "react";
+import firebaseApp from "./firebase";
+import { useAuth } from "./firebase.auth";
+
+const db = getFirestore(firebaseApp);
+
+export function createUser(uid, data) {
+  return setDoc(doc(db, 'users', uid), { uid, ...data }, { merge: true });
+}
+
+export const useDB = () => {
+  const { user } = useAuth();
+  const [ratings, setRatings] = useState({});
+  const [loading, setLoading] = useState(false);
+
+  const getRatings = async () => {
+    if (user) {
+      const userRatings = await getDoc(doc(db, 'users', user.uid));
+      return userRatings.data().ratings;
+    }
+  };
+
+  useEffect(() => {
+    setLoading(true);
+    getRatings().then(ratings => {
+      setRatings(ratings);
+      setLoading(false);
+    })
+  }, [user]);
+
+  return { ratings, loading, };
+}

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,6 +1,4 @@
 import { initializeApp } from 'firebase/app';
-import { FacebookAuthProvider, getAuth, GoogleAuthProvider, onAuthStateChanged, signInWithEmailAndPassword, signInWithPopup, signOut } from "firebase/auth";
-import { useEffect, useState } from 'react';
 
 
 const firebaseConfig = {
@@ -15,45 +13,5 @@ const firebaseConfig = {
 };
 
 const firebaseApp = initializeApp(firebaseConfig);
-
-const auth = getAuth();
-
-export const useAuth = () => {
-  const [user, setUser] = useState<undefined | { email: string, photoURL: string }>(undefined);
-  const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    setLoading(true)
-    onAuthStateChanged(auth, function handleAuth(user) {
-      if (user) {
-        setUser(user);
-        setLoading(false);
-      } else {
-        setUser(null);
-        setLoading(false)
-      }
-    });
-  }, [user]);
-
-  const signInWithGoogle = () => signInWithPopup(auth, new GoogleAuthProvider());
-
-  const signInWithPassword = async (email, password) => await signInWithEmailAndPassword(auth, email, password)
-    .then((userCredential) => {
-      // Signed in 
-      const user = userCredential.user;
-      console.log(user);
-      // ...
-    })
-    .catch((error) => {
-      const errorCode = error.code;
-      const errorMessage = error.message;
-      console.error(errorCode, errorMessage);
-    });
-
-  const signOutUser = () => signOut(auth);
-
-  return { user, loading, signInWithGoogle, signInWithPassword, signOutUser };
-}
-
 
 export default firebaseApp;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,11 @@
 import '../styles/globals.css'
 import { AppProps } from 'next/app'
+import { AuthProvider } from '../lib/firebase.auth'
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return <AuthProvider>
+    <Component {...pageProps} />
+  </AuthProvider>
 }
 
 export default MyApp

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -64,7 +64,7 @@ export default function Home({ posts }) {
 
       {auth?.user?.email ?
         <section>
-          <img src={auth.user.photoURL} alt="" className="photo" />
+          <img src={auth.user.photoUrl} alt="" className="photo" />
           {auth.user.email}
           <button onClick={handleSignOut}>Sign out</button>
         </section>
@@ -84,8 +84,9 @@ export default function Home({ posts }) {
 }
 
 export async function getStaticProps({ preview = null }) {
-  const res = await fetch('https://api.themoviedb.org/3/discover/movie?api_key=' + process.env.NEXT_PUBLIC_MOVIEDB_API_KEY);
-  const posts = await res.json();
+  // const res = await fetch('https://api.themoviedb.org/3/discover/movie?api_key=' + process.env.NEXT_PUBLIC_MOVIEDB_API_KEY);
+  // const posts = await res.json();
+  const posts = { results: [] };
   return {
     props: { posts, preview },
   }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,8 @@ import { getPerformance } from "firebase/performance";
 import Header from '../components/header/Header';
 import Footer from '../components/footer/Footer';
 import Ratings from '../components/ratings/Ratings';
-import firebaseApp, { useAuth } from '../lib/firebase';
+import firebaseApp from '../lib/firebase';
+import { useAuth } from '../lib/firebase.auth';
 
 if (process.browser) {
   getPerformance(firebaseApp);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,13 @@
-import Head from 'next/head'
-import Image from 'next/image'
-import Link from 'next/link'
-import styles from '../styles/Home.module.css'
 import { getPerformance } from "firebase/performance";
-import Header from '../components/header/Header';
+import Head from 'next/head';
+import Image from 'next/image';
+import Link from 'next/link';
 import Footer from '../components/footer/Footer';
+import Header from '../components/header/Header';
 import Ratings from '../components/ratings/Ratings';
 import firebaseApp from '../lib/firebase';
 import { useAuth } from '../lib/firebase.auth';
+import styles from '../styles/Home.module.css';
 
 if (process.browser) {
   getPerformance(firebaseApp);
@@ -23,13 +23,13 @@ export default function Home({ posts }) {
   const handlePassword = (event) => password = event.target.value;
 
   const handleSignIn = async () => {
-    auth.signInWithPassword(email, password);
+    auth.signinWithEmail(email, password);
   }
   const handleSignInGoogle = async () => {
-    auth.signInWithGoogle();
+    auth.signinWithGoogle();
   }
   const handleSignOut = async () => {
-    auth.signOutUser();
+    auth.signout();
   }
 
   return (

--- a/pages/movie/[id].tsx
+++ b/pages/movie/[id].tsx
@@ -1,24 +1,22 @@
+import Image from 'next/image';
 import Link from "next/link";
-import Image from 'next/image'
+import { useRouter } from "next/router";
 import useSWR from "swr";
-import {useRouter} from "next/router";
-import styles from "./Movie.module.css";
-import Header from "../../components/header/Header";
 import Footer from "../../components/footer/Footer";
+import Header from "../../components/header/Header";
 import Ratings from "../../components/ratings/Ratings";
+import styles from "./Movie.module.css";
 
 
 const fetcher = (url) => fetch(url).then(res => res.json());
 
 function MoviePage() {
     const router = useRouter()
-    const {id} = router.query
-    const {data, error} = useSWR(`https://api.themoviedb.org/3/movie/${id}?api_key=` + process.env.NEXT_PUBLIC_MOVIEDB_API_KEY, fetcher);
+    const { id } = router.query
+    const { data, error } = useSWR(`https://api.themoviedb.org/3/movie/${id}?api_key=` + process.env.NEXT_PUBLIC_MOVIEDB_API_KEY, fetcher);
 
     if (!data) return <p>Loading...</p>;
     if (error) return <p>Error :(</p>;
-
-    console.log(data);
 
     return <div>
         <Header />
@@ -56,7 +54,7 @@ function MoviePage() {
     </div>
 }
 
-const tmdbLoader = ({src, width, quality}) => {
+const tmdbLoader = ({ src, width, quality }) => {
     return `https://image.tmdb.org/t/p/w500/${src}?w=${width}&q=${quality || 75}`
 }
 


### PR DESCRIPTION
# User story
As an authenticated user
I can rate a movie
And see that rating during future sessions

# Implementation
## Data structure
An authenticated user is represented as a document in the `users` collection in Firestore. Ratings are saved for each user in the `ratings` map with the movieId as a key, and the given rating (from 1 to 5) as a value.

<img width="427" alt="image" src="https://user-images.githubusercontent.com/1059770/160882760-a4c40c73-aa44-4d0b-96de-715b273ff9ad.png">

## Data fetching
The list of ratings is fetched only one time, alongside the rest of the user data:
 * After the app has loaded, if the user is already authenticated
 * After the user successfully logged in, if the user was initially anonymous

The ratings are then saved in the AuthProvider.

When user rates a movie:
 * The ratings map in the AuthProvider is updated to reflect the change
 * Firestore function `setDoc` is called to update the ratings map in the database

closes #23 